### PR TITLE
feat!: change the API definition to seperate context from the caret

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-build-deploy/diagnose-it",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Expressive Diagnostics library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,32 @@ SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
 SPDX-License-Identifier: GPL-3.0-or-later
 */
 
-import * as path from "path";
 import assert from "assert";
 
 // Supported expressive types
 type ExpressiveType = "error" | "warning" | "note";
+
+/**
+ * Caret (^) position and length
+ * @interface ICaret
+ * @member index Index of the caret (^)
+ * @member length Length of the caret (^)
+ */
+interface ICaret {
+  index: number;
+  length: number;
+}
+
+/**
+ * Context around the error
+ * @interface IContext
+ * @member index Starting line number of the reported message
+ * @member lines Lines around the reported message
+ */
+interface IContext {
+  index: number;
+  lines: string[];
+}
 
 /**
  * Expressive Diagnostics message interface
@@ -25,12 +46,8 @@ interface IExpressiveMessage {
   type?: ExpressiveType;
   message: string;
   lineNumber?: number;
-  columnNumber?: number;
-  context?: {
-    index: number;
-    length: number;
-    lines: string[];
-  };
+  caret?: ICaret;
+  context?: IContext;
 }
 
 /**
@@ -55,7 +72,7 @@ interface IExpressiveMessage {
  * @function warning Warning message
  * @function note Information message
  * @function lineNumber Line number
- * @function columnNumber Column number
+ * @function caret Caret position and length
  * @function context Context around the error
  * @function toString Returns the formatted message
  *
@@ -66,24 +83,28 @@ export class ExpressiveMessage extends Error {
   private _type: ExpressiveType = "note";
   private _message?: string = undefined;
   private _lineNumber = 0;
-  private _columnNumber = 0;
-  private _context?: {
-    index: number;
-    length: number;
-    lines: string[];
-  };
+  private _caret: ICaret = { index: 0, length: 0 };
+  private _context?: IContext;
 
   constructor(message?: IExpressiveMessage) {
     super();
 
     if (message) {
-      this._id = message.id;
-      this._message = message.message;
-      this._type = message.type ?? "note";
-      this._lineNumber = message.lineNumber ?? 0;
-      this._columnNumber = message.columnNumber ?? 0;
-      this._context = message.context;
-      this.update();
+      this.id(message.id);
+      switch (message.type) {
+        case "error":
+          this.error(message.message);
+          break;
+        case "warning":
+          this.warning(message.message);
+          break;
+        case "note" || undefined:
+          this.note(message.message);
+          break;
+      }
+      this.lineNumber(message.lineNumber ?? 0);
+      if (message.context !== undefined) this.context(message.context.lines, message.context.index);
+      this.caret(message.caret?.index ?? 0, message.caret?.length ?? 0);
     }
   }
 
@@ -140,18 +161,26 @@ export class ExpressiveMessage extends Error {
    * @returns this
    */
   lineNumber(lineNumber: number): this {
+    if (lineNumber < 0) throw new RangeError("Line number must be greater or equal to 0.");
     this._lineNumber = lineNumber;
     this.update();
     return this;
   }
 
   /**
-   * Updates the column number associated with the message.
+   * Updates the caret associated with the message.
    * @param columnNumber Line number
+   * @param length Length of the caret
    * @returns this
    */
-  columnNumber(columnNumber: number): this {
-    this._columnNumber = columnNumber;
+  caret(columnNumber: number, length?: number): this {
+    if (columnNumber < 0) throw new RangeError("Column number must be greater or equal to 0.");
+    if (length !== undefined && length < 0) throw new RangeError("Caret length must be greater or equal to 0.");
+
+    this._caret = {
+      index: columnNumber,
+      length: length ?? 0,
+    };
     this.update();
     return this;
   }
@@ -160,12 +189,13 @@ export class ExpressiveMessage extends Error {
    * Updates the context (lines around the reposted message) associated with the message.
    * @param lines Lines around the reported message
    * @param start Start index of the reported message
-   * @param length Length of the reported message
    * @returns this
    */
-  context(lines: string | string[], start: number, length = 0): this {
+  context(lines: string | string[], start: number): this {
+    if (start < 0) throw new RangeError("Initial line number must be greater or equal to 0.");
+
     if (typeof lines === "string") lines = lines.split("\n");
-    this._context = { index: start, lines: lines, length: length };
+    this._context = { index: start, lines: lines.length > 0 ? lines : [] };
     this.update();
     return this;
   }
@@ -177,7 +207,7 @@ export class ExpressiveMessage extends Error {
     const GREEN = "\x1b[0;32m";
     const RED = "\x1b[1;31m";
 
-    this.message = `\x1b[1m${this._id}:${this._lineNumber}:${this._columnNumber}: ${
+    this.message = `\x1b[1m${this._id}:${this._lineNumber}:${this._caret.index}: ${
       this._type === "error" ? RED : GREEN
     }${this._type}:\x1b[0m\x1b[1m ${this._message}\x1b[0m`;
     if (this._context === undefined) return;
@@ -190,71 +220,34 @@ export class ExpressiveMessage extends Error {
       const lineNumber = this._context.index + index;
       let formattedLine = `  ${" ".repeat(maxWidth - lineNumber.toString().length)}${lineNumber} | ${line}\n`;
 
-      if (this._lineNumber !== lineNumber) {
-        formattedLine = `\u001b[38;5;245m${formattedLine}\u001b[0m`;
-      }
+      if (this._lineNumber !== lineNumber) formattedLine = `\u001b[38;5;245m${formattedLine}\u001b[0m`;
+
       this.message += formattedLine;
 
-      if (this._columnNumber !== undefined && this._lineNumber === lineNumber) {
-        this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._columnNumber)}\u001b[32;1m^${"-".repeat(
-          this._context.length > 0 ? this._context.length - 1 : 0
+      if (this._lineNumber === lineNumber) {
+        this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._caret.index)}\u001b[32;1m^${"-".repeat(
+          this._caret.length > 0 ? this._caret.length - 1 : 0
         )}\u001b[0m\n`;
       }
     });
   }
 
   /**
-   * Resets all internal variables.
-   * @returns this
-   */
-  private reset(): this {
-    this._id = undefined;
-    this._type = "note";
-    this._message = undefined;
-    this._lineNumber = 0;
-    this._columnNumber = 0;
-    this.message = "";
-    return this;
-  }
-
-  /**
    * Generates an Expressive Diagnostics message in formatted output.
    * @returns Formatted message
    */
-  toString(): string {
-    let error: ExpressiveMessage | undefined = undefined;
-
-    if (this._id === undefined) {
-      error = this.reset().error("No identifier (i.e. filename) has been provided.");
-    } else if (this._message === undefined) {
-      error = this.reset().error("No message has been specified.");
-    } else if (
-      this._context !== undefined &&
-      (this._lineNumber < this._context.index || this._lineNumber > this._context.index + this._context.lines.length)
-    ) {
-      error = this.reset().error("Line number is out of range.");
+  toString() {
+    if (this._context !== undefined) {
+      if (this._lineNumber < this._context.index || this._lineNumber > this._context.index + this._context.lines.length)
+        throw new RangeError(
+          `Line number (${this._lineNumber}) does not exist in provided context (lines ${this._context.index}-${
+            this._context.index + this._context.lines.length
+          }).`
+        );
     }
+    if (this._id === undefined) throw new Error("No identifier (i.e. filename) has been provided.");
+    if (this._message === undefined) throw new Error("No message has been specified.");
 
-    // We will throw an Expressive Diagnostics message using the original stack trace.
-    // However, this will require us to update the current instance and reconstruct
-    // the stack trace.
-    if (error !== undefined) {
-      const stackRegex = /at\s(.*)\s\((?<file>.*):(?<line>\d*):(?<col>\d*)\)/g;
-      assert(this.stack);
-
-      const match = stackRegex.exec(this.stack);
-      assert(match && match.groups && match.groups.file);
-
-      error = error
-        .id(path.relative(path.resolve(), match?.groups?.file))
-        .lineNumber(parseInt(match?.groups?.line ?? "0"))
-        .columnNumber(parseInt(match?.groups?.col ?? "0"));
-
-      assert(error.stack);
-      error.stack = error.stack.replace(/.*$/m, error.message);
-
-      throw error;
-    }
     return this.message;
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,7 +51,8 @@ describe("Expressive Message", () => {
       .id("example")
       .error("Subject")
       .lineNumber(6)
-      .context("Line 1\nLine 2\nLine 3", 5, 4);
+      .caret(0, 4)
+      .context("Line 1\nLine 2\nLine 3", 5);
     expect(removeColorCodes(message.toString())).toBe(`example:6:0: error: Subject
 
   5 | Line 1
@@ -63,7 +64,8 @@ describe("Expressive Message", () => {
       .id("example")
       .error("Subject")
       .lineNumber(99)
-      .context("Line 1\nLine 2\nLine 3", 99, 4);
+      .caret(0, 4)
+      .context("Line 1\nLine 2\nLine 3", 99);
     expect(removeColorCodes(message.toString())).toBe(`example:99:0: error: Subject
 
    99 | Line 1
@@ -80,7 +82,8 @@ describe("Expressive Message", () => {
         message: "Subject",
         type: "error",
         lineNumber: 0,
-        context: { index: 10, lines: ["Line 1", "Line 2", "Line 3"], length: 4 },
+        caret: { index: 0, length: 4 },
+        context: { index: 10, lines: ["Line 1", "Line 2", "Line 3"] },
       }).toString();
     }).toThrowError();
   });
@@ -92,7 +95,32 @@ describe("Expressive Message", () => {
         message: "Subject",
         type: "error",
         lineNumber: 0,
-        context: { index: 0, lines: ["Line 1", "Line 2", "Line 3"], length: 0 },
+        caret: { index: 0, length: 0 },
+        context: { index: 0, lines: ["Line 1", "Line 2", "Line 3"] },
+      }).toString();
+    }).not.toThrowError();
+  });
+
+  test("Caret out of bounds", () => {
+    expect(() => {
+      new ExpressiveMessage({
+        id: "example",
+        message: "Subject",
+        type: "error",
+        lineNumber: -1,
+        caret: { index: -1, length: -1 },
+        context: { index: -1, lines: ["Line 1"] },
+      });
+    }).toThrowError();
+
+    expect(() => {
+      new ExpressiveMessage({
+        id: "example",
+        message: "Subject",
+        type: "error",
+        lineNumber: 0,
+        caret: { index: 10, length: 4 },
+        context: { index: 0, lines: ["Line 1"] },
       }).toString();
     }).not.toThrowError();
   });


### PR DESCRIPTION
This commit will introduce few breaking changes:
- The `length` parameter has been removed from `context()`
- A new `caret()` function is added to replace `columnNumber` and `context.length`
- Improve boundary checks for provided input parameters