### PR TITLE
feat!: update type-functions (`error()`...) to be static constructors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules
 npm-debug.log
 lib/
+coverage/

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ const lines = `steps:
     - uses: actions/setup-node@v2`;
 
 // Example using Method chaining
-const chainedMessage = new ExpressiveMessage()
-  .id("example.yaml")
-  .error("Invalid keyword 'neds'")
+const chainedMessage = ExpressiveMessage
+  // Create an instance of ExpressiveMessage
+  .error("example.yaml", "Invalid keyword 'neds'")
+  // Set additional properties
   .lineNumber(9)
   .caret(4, 4)
   .hint("needs")

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "tsc --project tsconfig.publish.json",
-    "test": "jest",
+    "test": "jest --coverage",
     "lint": "eslint --ext .ts .",
     "format": "prettier --write **/*.ts && prettier --write **/*.ts"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,5 @@
  * SPDX-License-Identifier: MIT
  */
 
-export { ExpressiveMessage, ExpressiveType } from "./diagnostics";
+export { ExpressiveMessage, ExpressiveType, ICaret, IContext, IExpressiveMessage } from "./diagnostics";
 export { extractFromFile, extractFromSarif } from "./parser";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,7 @@
-/* 
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 
 import { ExpressiveMessage, extractFromFile } from "../src/index";
 import * as fs from "fs";
@@ -14,7 +14,7 @@ const removeColorCodes = (str: string) => str.replace(/\x1b\[[0-9;]*m/g, "");
 
 describe("Expressive Message", () => {
   test("Minimal usage", () => {
-    expect(removeColorCodes(new ExpressiveMessage().id("example").error("Subject").toString())).toBe(
+    expect(removeColorCodes(ExpressiveMessage.error("example", "Subject").toString())).toBe(
       "example:1:1: error: Subject"
     );
     expect(
@@ -29,27 +29,22 @@ describe("Expressive Message", () => {
     expect(() => {
       new ExpressiveMessage().id("example").toString();
     }).toThrowError();
-    expect(() => {
-      new ExpressiveMessage().error("Subject").toString();
-    }).toThrowError();
   });
 
   test("Supported message types (error|warning|note)", () => {
-    expect(removeColorCodes(new ExpressiveMessage().id("example").error("Subject").toString())).toBe(
+    expect(removeColorCodes(ExpressiveMessage.error("example", "Subject").toString())).toBe(
       "example:1:1: error: Subject"
     );
-    expect(removeColorCodes(new ExpressiveMessage().id("example").note("Subject").toString())).toBe(
+    expect(removeColorCodes(ExpressiveMessage.note("example", "Subject").toString())).toBe(
       "example:1:1: note: Subject"
     );
-    expect(removeColorCodes(new ExpressiveMessage().id("example").warning("Subject").toString())).toBe(
+    expect(removeColorCodes(ExpressiveMessage.warning("example", "Subject").toString())).toBe(
       "example:1:1: warning: Subject"
     );
   });
 
   test("Context", () => {
-    let message = new ExpressiveMessage()
-      .id("example")
-      .error("Subject")
+    let message = ExpressiveMessage.error("example", "Subject")
       .lineNumber(6)
       .caret(1, 4)
       .context("Line 1\nLine 2\nLine 3", 5);
@@ -60,9 +55,7 @@ describe("Expressive Message", () => {
     | ^---
   7 | Line 3
 `);
-    message = new ExpressiveMessage()
-      .id("example")
-      .error("Subject")
+    message = ExpressiveMessage.error("example", "Subject")
       .lineNumber(99)
       .caret(1, 4)
       .context("Line 1\nLine 2\nLine 3", 99);
@@ -137,9 +130,7 @@ describe("Expressive Message", () => {
   });
 
   test("Fix-it Hint", () => {
-    const message = new ExpressiveMessage()
-      .id("example")
-      .error("Subject")
+    const message = ExpressiveMessage.error("example", "Subject")
       .lineNumber(99)
       .caret(1, 4)
       .hint("Line")


### PR DESCRIPTION
In order to reduce the overhead of creating new `error`, `warning`, and `note` instances, the respective functions have been updated to be statically accessible and return a new instance of `ExpressiveMessage`