### PR TITLE
feat: add ability to generate `patch` files based on FixIt Hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Lightweight diagnostics logger, based on [LLVMs Expressive Diagnostics specifica
 ## Features
 
 * Simple to use
-* Based on [LLVMs Expressive Diagnostics specification]
+* Inspired by the [LLVMs Expressive Diagnostics specification]
 * Provide context to your diagnostics messages
 
 ## Usage
@@ -22,31 +22,30 @@ Lightweight diagnostics logger, based on [LLVMs Expressive Diagnostics specifica
 
 ```ts
 import { DiagnosticsMessage, FixItHint } from '@dev-build-deploy/diagnose-it';
-
 const lines = `steps:
   - uses: actions/checkout@v2
   - neds: [build, test]
     - uses: actions/setup-node@v2`;
-
+  
 // Example use case
 const message = DiagnosticsMessage.createError(
   "example.yaml",
   {
     text: "Invalid keyword 'neds'",
     linenumber: 9,
-    column: 4
+    column: 5
   }
 )
   // Add context to the diagnostics message
   .setContext(7, lines)
   // Add a FixIt Hint
-  .addFixitHint(FixItHint.createReplacement({index: 5, length: 4}, "needs"));
+  .addFixitHint(FixItHint.createReplacement({ index: 5, length: 4 }, "needs"));
 
 // Convert to string
 console.log(message.toString());
 
 // Apply FixIt Hints
-console.log("Results after applying FixIt Hints:", message.applyFixitHints())
+console.log("Results after applying FixIt Hints:", message.applyFixitHints());
 
 // Throw as an Error
 throw message;
@@ -70,13 +69,15 @@ for await(const message of diagnoseIt.extractFromFile("build.log")) {
 
 ## Output format
 
-DiagnoseIt is based on the [LLVMs Expressive Diagnostics formatting](https://clang.llvm.org/diagnostics.html);
+`DiagnoseIt` is inspired by the [LLVMs Expressive Diagnostics formatting](https://clang.llvm.org/diagnostics.html);
 
 <img src="./docs/formatting.svg">
 
+*However, it does not aim to provide full compatibility.*
+
 ## Contributing
 
-If you have suggestions for how diagnose-it could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
+If you have suggestions for how `DiagnoseIt` could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
 
 For more, check out the [Contributing Guide](CONTRIBUTING.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@dev-build-deploy/sarif-it": "<1",
-        "chalk": "<5"
+        "chalk": "<5",
+        "diff": "^5.1.0"
       },
       "devDependencies": {
+        "@types/diff": "^5.0.8",
         "@types/jest": "^29.5.2",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.11",
@@ -46,9 +48,9 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.4.tgz",
-      "integrity": "sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.23.4",
@@ -130,30 +132,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
-      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
-      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
+      "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.5",
         "@babel/helper-compilation-targets": "^7.22.15",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.3",
+        "@babel/helpers": "^7.23.5",
+        "@babel/parser": "^7.23.5",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.3",
-        "@babel/types": "^7.23.3",
+        "@babel/traverse": "^7.23.5",
+        "@babel/types": "^7.23.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -178,12 +180,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.4.tgz",
-      "integrity": "sha512-esuS49Cga3HcThFNebGhlgsrVLkvhqvYDTzgjfFFlHJcIfLe5jFmRRfCQ1KuBfc4Jrtn3ndLgKWAKjBE+IraYQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+      "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.4",
+        "@babel/types": "^7.23.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -334,23 +336,23 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.4.tgz",
-      "integrity": "sha512-HfcMizYz10cr3h29VqyfGL6ZWIjTwWfvYBMsBVGwpcbhNGe3wQ1ZXZRPzZoAHhd9OqHadHqjQ89iVKINXnbzuw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
+      "integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.4",
-        "@babel/types": "^7.23.4"
+        "@babel/traverse": "^7.23.5",
+        "@babel/types": "^7.23.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -442,9 +444,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.4.tgz",
-      "integrity": "sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -645,19 +647,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.4.tgz",
-      "integrity": "sha512-IYM8wSUwunWTB6tFC2dkKZhxbIjHoWemdK+3f8/wq8aKhbUscxD5MX72ubd90fxvFknaLPeGw5ycU84V1obHJg==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+      "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.23.4",
-        "@babel/generator": "^7.23.4",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.4",
-        "@babel/types": "^7.23.4",
+        "@babel/parser": "^7.23.5",
+        "@babel/types": "^7.23.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -675,9 +677,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.4.tgz",
-      "integrity": "sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+      "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.23.4",
@@ -1325,6 +1327,12 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/diff": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.8.tgz",
+      "integrity": "sha512-kR0gRf0wMwpxQq6ME5s+tWk9zVCfJUl98eRkD05HWWRbhPB/eu4V1IbyZAsvzC1Gn4znBJ0HN01M4DGXdBEV8Q==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1359,9 +1367,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.9.tgz",
-      "integrity": "sha512-zJeWhqBwVoPm83sP8h1/SVntwWTu5lZbKQGCvBjxQOyEWnKnsaomt2y7SlV4KfwlrHAHHAn00Sh4IAWaIsGOgQ==",
+      "version": "29.5.10",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.10.tgz",
+      "integrity": "sha512-tE4yxKEphEyxj9s4inideLHktW/x6DwesIwWZ9NN1FKf9zbJYsnhBoA9vrHA/IuIOKwPa5PcFBNV4lpMIOEzyQ==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -1375,9 +1383,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.3.tgz",
-      "integrity": "sha512-nk5wXLAXGBKfrhLB0cyHGbSqopS+nz0BUgZkUQqSHSSgdee0kssp1IAqlQOu333bW+gMNs2QREx7iynm19Abxw==",
+      "version": "20.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
+      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1946,9 +1954,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001563",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
-      "integrity": "sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==",
+      "version": "1.0.30001565",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
+      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
       "dev": true,
       "funding": [
         {
@@ -2158,6 +2166,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2192,9 +2208,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.589",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.589.tgz",
-      "integrity": "sha512-zF6y5v/YfoFIgwf2dDfAqVlPPsyQeWNpEWXbAlDUS8Ax4Z2VoiiZpAPC0Jm9hXEkJm2vIZpwB6rc4KnLTQffbQ==",
+      "version": "1.4.596",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.596.tgz",
+      "integrity": "sha512-zW3zbZ40Icb2BCWjm47nxwcFGYlIgdXkAx85XDO7cyky9J4QQfq8t0W19/TLZqq3JPQXtlv8BPIGmfa9Jb4scg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4741,9 +4757,9 @@
       }
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/dev-build-deploy/diagnose-it#readme",
   "devDependencies": {
+    "@types/diff": "^5.0.8",
     "@types/jest": "^29.5.2",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
@@ -42,6 +43,7 @@
   ],
   "dependencies": {
     "@dev-build-deploy/sarif-it": "<1",
-    "chalk": "<5"
+    "chalk": "<5",
+    "diff": "^5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "tsc --project tsconfig.publish.json",
-    "test": "jest --coverage",
+    "test": "TZ=utc jest --coverage",
     "lint": "eslint --ext .ts .",
     "format": "prettier --write **/*.ts && prettier --write **/*.ts"
   },

--- a/src/diagnosticsMessage.ts
+++ b/src/diagnosticsMessage.ts
@@ -5,6 +5,7 @@
 
 import chalk from "chalk";
 import { FixItHint, ModificationColorCodes } from "./fixitHint";
+import { applyPatch, createPatch } from "./diff";
 
 /**
  * Diagnostics Message Level
@@ -431,30 +432,11 @@ export class DiagnosticsMessage {
     return message.join("\n");
   }
 
+  /**
+   * Applies the FixIt hints to the context and returns the result as a string.
+   * @returns Fixed string
+   */
   applyFixitHints(): string {
-    if (this.context === undefined) {
-      throw new Error("Cannot apply FixIt hints without a context.");
-    }
-
-    let result = this.context.lines[(this.message.linenumber ?? 1) - this.context.linenumber];
-
-    this.fixitHints.forEach(fixit => {
-      switch (fixit.modification) {
-        case "INSERT":
-          result = result.slice(0, fixit.range.index - 1) + fixit.text + result.slice(fixit.range.index - 1);
-          break;
-        case "REMOVE":
-          result = result.slice(0, fixit.range.index - 1) + result.slice(fixit.range.index - 1 + fixit.range.length);
-          break;
-        case "REPLACE":
-          result =
-            result.slice(0, fixit.range.index - 1) +
-            fixit.text +
-            result.slice(fixit.range.index - 1 + fixit.range.length);
-          break;
-      }
-    });
-
-    return result;
+    return applyPatch(createPatch(this));
   }
 }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+import fs from "fs";
+import * as diff from "diff";
+import { DiagnosticsMessage } from "./diagnosticsMessage";
+
+/**
+ * Creates a patch based on an unified Diff.
+ *
+ * NOTE: This is not a full implementation of the unified Diff format,
+ *       but only supports the bare minimum required to create a patch
+ *       that applies Fix-It Hints, covering a single line in a single
+ *       hunk.
+ * @returns Patch.
+ */
+export function createPatch(message: DiagnosticsMessage): string {
+  if (message.context === undefined) {
+    throw new Error("Cannot apply FixIt hints without a context.");
+  }
+
+  // get modification date of file as Date object
+  const stats = fs.existsSync(message.file) ? fs.statSync(message.file) : undefined;
+  const mtime = stats ? new Date(stats.mtimeMs) : new Date();
+
+  const original = message.context?.lines[(message.message.linenumber ?? 1) - message.context.linenumber];
+
+  // apply fixit hints to original string
+  let expected = original;
+
+  // each fixit hint modifies the string, so we need to keep track of the offset
+  let offset = 0;
+
+  // Use a copy of the array to prevent modifying the original
+  const fixitHints = [...message.getFixitHints()];
+
+  fixitHints.forEach(fixit => {
+    fixit.range.index += offset;
+    expected = fixit.apply(expected);
+
+    // update offset based on modification type
+    switch (fixit.modification) {
+      case "INSERT":
+        offset += fixit.text?.length ?? 0;
+        break;
+      case "REMOVE":
+        offset -= fixit.range.length;
+        break;
+      case "REPLACE":
+        offset += (fixit.text?.length ?? fixit.range.length) - fixit.range.length;
+        break;
+    }
+  });
+
+  const linenumber = message.context.linenumber;
+  const linecount = message.context.lines.length;
+
+  let result = `--- ${message.file} ${mtime.toLocaleString("en-GB")}
++++ ${message.file}.fix ${new Date().toLocaleString("en-GB")}
+@@ -${linenumber},${linecount} +${linenumber},${linecount} @@`;
+
+  for (const line of message.context?.lines ?? []) {
+    const modification = line === original && original !== expected;
+    result += `\n${modification ? "-" : " "}${line}`;
+    if (modification) {
+      result += `\n+${expected}`;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Applies a patch (see createPatch) to a file using a Buffer.
+ * @param patch
+ * @internal
+ */
+export function applyPatch(patch: string): string {
+  const filename = patch.split(/\r?\n/)[0].split(" ")[1];
+  const source = fs.readFileSync(filename, "utf-8");
+  const res = diff.applyPatch(source, patch);
+  if (res === false) {
+    throw new Error("Failed to apply patch");
+  }
+
+  return res;
+}

--- a/src/fixitHint.ts
+++ b/src/fixitHint.ts
@@ -127,4 +127,27 @@ export class FixItHint {
   static createRemoval(range: RangeType): FixItHint {
     return new FixItHint("REMOVE", range);
   }
+
+  /**
+   * Applies the fix-it hint to the provided line
+   * @param line Line to apply the fix-it hint to
+   * @returns Line with the fix-it hint applied
+   */
+  apply(line: string): string {
+    let result = line;
+    switch (this.modification) {
+      case "INSERT":
+        result = result.slice(0, this.range.index - 1) + this.text + result.slice(this.range.index - 1);
+        break;
+      case "REMOVE":
+        result = result.slice(0, this.range.index - 1) + result.slice(this.range.index - 1 + this.range.length);
+        break;
+      case "REPLACE":
+        result =
+          result.slice(0, this.range.index - 1) + this.text + result.slice(this.range.index - 1 + this.range.length);
+        break;
+    }
+
+    return result;
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,5 @@ export {
 export { FixItHint, RangeType, ModificationType } from "./fixitHint";
 
 export { extractFromFile, extractFromSarif } from "./parser";
+
+export { createPatch } from "./diff";

--- a/test/diagnosticsMessage.test.ts
+++ b/test/diagnosticsMessage.test.ts
@@ -359,7 +359,6 @@ describe("FixIt Hints (incl. applying fixes)", () => {
           )
         );
       expect(unchalk(msg.toString())).toBe(data.expected);
-      expect(msg.applyFixitHints()).toBe(data.fixed);
       expect(msg.getFixitHints().length).toBe(1);
       expect(msg.getFixitHints()[0].modification).toBe(data.input.fixit.modification as ModificationType);
 

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+import { DiagnosticsLevelEnum, DiagnosticsMessage } from "../src/diagnosticsMessage";
+import { applyPatch, createPatch } from "../src/diff";
+import { FixItHint } from "../src/fixitHint";
+
+import fs from "fs";
+
+jest.mock("fs", () => ({
+  promises: {
+    access: jest.fn(),
+  },
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
+
+describe("Create and Apply Patch", () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2020-01-01"));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const testData = [
+    {
+      description: "No FixIt hints",
+      patch: `--- example.py 01/01/2020, 01:00:00
++++ example.py.fix 01/01/2020, 01:00:00
+@@ -1,3 +1,3 @@
+ Line 1
+ Line 2
+ Line 3`,
+      fix: `Line 1
+Line 2
+Line 3`,
+    },
+    {
+      description: "Single Insertion FixIt hint",
+      fixit: [FixItHint.createInsertion(1, "First ")],
+      patch: `--- example.py 01/01/2020, 01:00:00
++++ example.py.fix 01/01/2020, 01:00:00
+@@ -1,3 +1,3 @@
+-Line 1
++First Line 1
+ Line 2
+ Line 3`,
+      fix: `First Line 1
+Line 2
+Line 3`,
+    },
+    {
+      description: "Single Removal FixIt hint",
+      fixit: [FixItHint.createRemoval({ index: 5, length: 2 })],
+      patch: `--- example.py 01/01/2020, 01:00:00
++++ example.py.fix 01/01/2020, 01:00:00
+@@ -1,3 +1,3 @@
+-Line 1
++Line
+ Line 2
+ Line 3`,
+      fix: `Line
+Line 2
+Line 3`,
+    },
+    {
+      description: "Single Replacement FixIt hint",
+      fixit: [FixItHint.createReplacement({ index: 1, length: 6 }, "First")],
+      patch: `--- example.py 01/01/2020, 01:00:00
++++ example.py.fix 01/01/2020, 01:00:00
+@@ -1,3 +1,3 @@
+-Line 1
++First
+ Line 2
+ Line 3`,
+      fix: `First
+Line 2
+Line 3`,
+    },
+    {
+      description: "Multiple FixIt hints",
+      fixit: [FixItHint.createInsertion(1, "First "), FixItHint.createRemoval({ index: 5, length: 2 })],
+      patch: `--- example.py 01/01/2020, 01:00:00
++++ example.py.fix 01/01/2020, 01:00:00
+@@ -1,3 +1,3 @@
+-Line 1
++First Line
+ Line 2
+ Line 3`,
+      fix: `First Line
+Line 2
+Line 3`,
+    },
+  ];
+
+  testData.forEach(({ description, fixit, patch, fix }) => {
+    test(description, () => {
+      const fileContents = `Line 1
+Line 2
+Line 3`;
+      jest.spyOn(fs, "readFileSync").mockImplementation(() => fileContents);
+      jest.spyOn(fs, "existsSync").mockImplementation(() => false);
+
+      const message = new DiagnosticsMessage({
+        file: "example.py",
+        level: DiagnosticsLevelEnum.Error,
+        message: { text: description, linenumber: 1, column: 1 },
+      });
+
+      message.setContext(1, fileContents);
+
+      if (fixit) {
+        fixit.forEach(hint => message.addFixitHint(hint));
+      }
+      const patchResults = createPatch(message);
+
+      expect(patchResults).toBe(patch);
+      expect(applyPatch(patchResults)).toBe(fix);
+    });
+  });
+});

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -29,8 +29,8 @@ describe("Create and Apply Patch", () => {
   const testData = [
     {
       description: "No FixIt hints",
-      patch: `--- example.py 01/01/2020, 01:00:00
-+++ example.py.fix 01/01/2020, 01:00:00
+      patch: `--- example.py 01/01/2020, 00:00:00
++++ example.py.fix 01/01/2020, 00:00:00
 @@ -1,3 +1,3 @@
  Line 1
  Line 2
@@ -42,8 +42,8 @@ Line 3`,
     {
       description: "Single Insertion FixIt hint",
       fixit: [FixItHint.createInsertion(1, "First ")],
-      patch: `--- example.py 01/01/2020, 01:00:00
-+++ example.py.fix 01/01/2020, 01:00:00
+      patch: `--- example.py 01/01/2020, 00:00:00
++++ example.py.fix 01/01/2020, 00:00:00
 @@ -1,3 +1,3 @@
 -Line 1
 +First Line 1
@@ -56,8 +56,8 @@ Line 3`,
     {
       description: "Single Removal FixIt hint",
       fixit: [FixItHint.createRemoval({ index: 5, length: 2 })],
-      patch: `--- example.py 01/01/2020, 01:00:00
-+++ example.py.fix 01/01/2020, 01:00:00
+      patch: `--- example.py 01/01/2020, 00:00:00
++++ example.py.fix 01/01/2020, 00:00:00
 @@ -1,3 +1,3 @@
 -Line 1
 +Line
@@ -70,8 +70,8 @@ Line 3`,
     {
       description: "Single Replacement FixIt hint",
       fixit: [FixItHint.createReplacement({ index: 1, length: 6 }, "First")],
-      patch: `--- example.py 01/01/2020, 01:00:00
-+++ example.py.fix 01/01/2020, 01:00:00
+      patch: `--- example.py 01/01/2020, 00:00:00
++++ example.py.fix 01/01/2020, 00:00:00
 @@ -1,3 +1,3 @@
 -Line 1
 +First
@@ -84,8 +84,8 @@ Line 3`,
     {
       description: "Multiple FixIt hints",
       fixit: [FixItHint.createInsertion(1, "First "), FixItHint.createRemoval({ index: 5, length: 2 })],
-      patch: `--- example.py 01/01/2020, 01:00:00
-+++ example.py.fix 01/01/2020, 01:00:00
+      patch: `--- example.py 01/01/2020, 00:00:00
++++ example.py.fix 01/01/2020, 00:00:00
 @@ -1,3 +1,3 @@
 -Line 1
 +First Line

--- a/test/readme.test.ts
+++ b/test/readme.test.ts
@@ -5,21 +5,53 @@
 
 import { DiagnosticsMessage, FixItHint } from "../src/index";
 
+import fs from "fs";
+
+jest.mock("fs", () => ({
+  promises: {
+    access: jest.fn(),
+  },
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
+
 describe("ReadMe tests", () => {
   test("Example code", () => {
-    const lines = `steps:
-  - uses: actions/checkout@v2
-  - neds: [build, test]
-    - uses: actions/setup-node@v2`;
+    const fileContents = `name: Example Workflow
+
+jobs:
+  example-run:
+    name: Example failure
+    runs-on: ubuntu-latest
+    neds: [build, test]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2`;
+
+    const expected = `name: Example Workflow
+
+jobs:
+  example-run:
+    name: Example failure
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2`;
+
+    jest.spyOn(fs, "readFileSync").mockImplementation(() => fileContents);
+    jest.spyOn(fs, "existsSync").mockImplementation(() => false);
+
+    const lines = fileContents.split(/\r?\n/).splice(4, 5);
 
     // Example use case
     const message = DiagnosticsMessage.createError("example.yaml", {
       text: "Invalid keyword 'neds'",
-      linenumber: 9,
+      linenumber: 7,
       column: 5,
     })
       // Add context to the diagnostics message
-      .setContext(7, lines)
+      .setContext(5, lines)
       // Add a FixIt Hint
       .addFixitHint(FixItHint.createReplacement({ index: 5, length: 4 }, "needs"));
 
@@ -29,6 +61,6 @@ describe("ReadMe tests", () => {
     // Apply FixIt Hints
     console.log("Results after applying FixIt Hints:", message.applyFixitHints());
 
-    expect(message.applyFixitHints()).toBe("  - needs: [build, test]");
+    expect(message.applyFixitHints()).toBe(expected);
   });
 });


### PR DESCRIPTION
This change introduces `createPatch()`, which allows you to create a unix `patch` file-string based on the Fix-It Hints associated with the `DiagnosticsMessage`.

This can be useful in case you want to generate your own `patch`-files and use the `patch`-cli tool to apply your patches.

If you want to directly apply the `patch` to the associated file, then simply use `DiagnosticsMessage.applyFixitHints()` (as was already exposed in the previous version).